### PR TITLE
Only shuffle block permutation once per block

### DIFF
--- a/SpmCrypt64/SpmBlockCipher64.h
+++ b/SpmCrypt64/SpmBlockCipher64.h
@@ -87,7 +87,7 @@ protected:
 
     void PermuteSbox();
 
-    void ShuffleBlockPermutation(__out_ecount(k_cSpmBlockSizeBytes) unsigned char* rgBlockPermutation, __in_ecount_opt(k_cSpmBlockSizeBytes) SPM_SBOX_WORD* prgBlockPermutationEntropy = NULL);
+    void ShuffleBlockPermutation(__out_ecount(k_cSpmBlockSizeBytes) unsigned char* rgBlockPermutation);
     void ReverseBlockPermutation(__in_ecount(k_cSpmBlockSizeBytes) const unsigned char* rgBlockPermutation, __out_ecount(k_cSpmBlockSizeBytes) unsigned char* rgReverseBlockPermutation);
 
 public:

--- a/SpmCrypt64/UnitTests.cpp
+++ b/SpmCrypt64/UnitTests.cpp
@@ -59,8 +59,8 @@ void UnitTests::s_PermutationEncryptTest()
     nMatchCount = s_CompareBytes(pTestData, pBuffer, k_cSpmBlockSizeBytes * 2);
     ASSERT(nMatchCount < 8);
 
-    ASSERT(pBuffer[0] == 0x10);
-    ASSERT(pBuffer[k_cSpmBlockSizeBytes * 2 - 1] == 0xe5);
+    ASSERT(pBuffer[0] == 0x8b);
+    ASSERT(pBuffer[k_cSpmBlockSizeBytes * 2 - 1] == 0xdb);
 
     fbcDecrypt.Decrypt(pBuffer, k_cSpmBlockSizeBytes * 2);
     nMatchCount = s_CompareBytes(pTestData, pBuffer, k_cSpmBlockSizeBytes * 2);
@@ -129,8 +129,8 @@ void UnitTests::s_NonceTest()
     printf("Encrypted Nonce:\n");
     PrintBin(rgTemp, OneWayHash.s_GetKeyWidth());
     printf("\n");
-    ASSERT(rgTemp[0] == 0xFD);
-    ASSERT(rgTemp[FBC_CRYPT::s_GetKeyWidth()-1] == 0xD3);
+    ASSERT(rgTemp[0] == 0xf2);
+    ASSERT(rgTemp[FBC_CRYPT::s_GetKeyWidth()-1] == 0xa9);
 }
 
 // test if a single bit is changed in the input all output bits change with equal likelihood.

--- a/SpmCryptNetTests/SpmBlockCipherTests.cs
+++ b/SpmCryptNetTests/SpmBlockCipherTests.cs
@@ -32,7 +32,7 @@ namespace Spm.Tests
             encryptor.SetKeys(key);
             decryptor.SetKeys(key);
 
-            TestEncryption(encryptor, decryptor, 0x10, 0xe5);
+            TestEncryption(encryptor, decryptor, 0x8b, 0xdb);
         }
 
         private static void TestEncryption(SpmBlockCipher encryptor, SpmBlockCipher decryptor, byte firstByte, byte lastByte)
@@ -76,7 +76,7 @@ namespace Spm.Tests
             Util.ApplyNonce(nonce, key, encryptor);
             Util.ApplyNonce(nonce, key, decryptor);
 
-            TestEncryption(encryptor, decryptor, 0x4f, 0x4a);
+            TestEncryption(encryptor, decryptor, 0xe0, 0xfa);
         }
 
         private static int CompareBytes(byte[] pTestData, byte[] pBuffer)


### PR DESCRIPTION
It is not necessary to re-shuffle the block permutation for every round for each block, and the code is alot simpler if we only shuffle it once at the beginning of each block.  That way we dont need to have an entropy buffer for the shuffling for each round when we decrypt.